### PR TITLE
setup.py fixes

### DIFF
--- a/droidconfig.py
+++ b/droidconfig.py
@@ -7,7 +7,7 @@ APKTOOL_JAR = os.path.join( os.path.expanduser("~/softs"), "apktool_2.4.1.jar")
 BAKSMALI_JAR = os.path.join(os.path.expanduser("~/softs"), "baksmali-2.4.0.jar")
 DEX2JAR_CMD = os.path.join(os.path.expanduser("~/softs/dex-tools-2.1-SNAPSHOT"), "d2j-dex2jar.sh")
 PROCYON_JAR = os.path.join( os.path.expanduser("~/softs"), "procyon-decompiler-0.5.30.jar")
-INSTALL_DIR = os.path.expanduser("~/git/droidlysis")
+INSTALL_DIR = os.path.dirname(__file__)
 SQLALCHEMY = 'sqlite:///droidlysis.db' # https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
 KEYTOOL = os.path.join( "/usr/bin/keytool" )
 

--- a/droidlysis
+++ b/droidlysis
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import droidlysis3
+
+if __name__ == "__main__":
+    droidlysis3.check_python_version()
+    args = droidlysis3.get_arguments()
+    droidlysis3.process_input(args)
+    print("END")

--- a/droidlysis3.py
+++ b/droidlysis3.py
@@ -131,11 +131,5 @@ def check_python_version():
     if sys.version_info.major < 3:
         print("ERROR: Please run DroidLysis with Python 3")
         quit()
-        
-if __name__ == "__main__":
-    check_python_version()
-    args = get_arguments()
-    process_input(args)
-    print("END")
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,18 @@ setup(
     python_requires='>=3.0.*',
     version = '3.1.0',
     packages=['conf'],
+    py_modules=[
+        'droidconfig',
+        'droidcountry',
+        'droidlysis3',
+        'droidproperties',
+        'droidreport',
+        'droidsample',
+        'droidsql',
+        'droidurl',
+        'droidutil',
+        'droidziprar',
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
@@ -27,5 +39,5 @@ setup(
     ],
     include_package_data=True,
     install_requires=[ 'configparser', 'python-magic', 'SQLAlchemy', 'rarfile', 'androguard' ],
-    scripts = [ 'droidlysis3.py', 'droidconfig.py', 'droidcountry.py', 'droidproperties.py', 'droidreport.py', 'droidsample.py', 'droidsql.py', 'droidurl.py', 'droidutil.py', 'droidziprar.py' ],
+    scripts = [ 'droidlysis' ],
 )

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,6 @@ setup(
         "Topic :: Software Development :: Disassemblers",
     ],
     include_package_data=True,
-    install_requires=[ 'configparser', 'python-magic', 'SQLAlchemy', 'rarfile', 'androguard' ],
+    install_requires=[ 'python-magic', 'SQLAlchemy', 'rarfile', 'androguard' ],
     scripts = [ 'droidlysis' ],
 )


### PR DESCRIPTION
Thanks for adding _setup.py_ #3.  This tweaks the _setup.py_ so that the files get automatically installed into the right places.      The modules don't go into `scripts`, only the command line executables. So this moves the modules to the right place to make them get installed, then makes a command line script that just calls the modules called `droidlysis`.

This also automatically sets `INSTALL_DIR` based on `__file__ ` which provides the full path to the current file.  