### PR TITLE
newer libmagic version detect Android APK files

### DIFF
--- a/droidutil.py
+++ b/droidutil.py
@@ -182,7 +182,7 @@ def get_filetype(filename):
     if filetype == None:
         # this happens if magic is unable to find file type
         return UNKNOWN
-    match = re.search('Zip archive data|zip|RAR archive data|executable, ARM|shared object, ARM|Java class|Dalvik dex|Java archive', filetype)
+    match = re.search('Zip archive data|zip|RAR archive data|executable, ARM|shared object, ARM|Java class|Dalvik dex|Java archive|Android package', filetype)
     if match == None:
         mytype = UNKNOWN
     else:
@@ -194,6 +194,7 @@ def get_filetype(filename):
                      'shared object, ARM' : ARM,
                      'Java class' : CLASS,
                      'Dalvik dex' : DEX,
+                     'Android package' : ZIP,  # droidsample needs ZIP type to do all the processing
                      'None' : UNKNOWN   }
         mytype = typecase[match.group(0)]
     return mytype


### PR DESCRIPTION
These are possible values for APKs as returned from libmagic 0.4.26:

* Android package (APK), with AndroidManifest.xml
* Android package (APK), with AndroidManifest.xml, with APK Signing Block
* Android package (APK), with classes.dex, with APK Signing Block
* Android package (APK), with MANIFEST.MF and armeabi lib
* Android package (APK), with MANIFEST.MF and resources.arsc
* Java archive data (JAR)