### PR TITLE
use standard UNIX config paths when ./conf/general.conf does not exist

### DIFF
--- a/droidconfig.py
+++ b/droidconfig.py
@@ -13,7 +13,23 @@ logging.basicConfig(format='%(levelname)s:%(filename)s:%(message)s',
 
 # ------------------------- Reading *.conf configuration files -----------
 class generalconfig:
-    def __init__(self, filename='./conf/general.conf', verbose=False):
+    def __init__(self, filename, verbose=False):
+        if not filename:
+            filename = './conf/general.conf'
+        if not os.path.exists(filename):
+            try:
+                from xdg.BaseDirectory import xdg_config_home
+
+                config = xdg_config_home
+            except ImportError:
+                config = os.path.join(os.getenv('HOME'), '.config')
+            if not os.path.exists(config):
+                config = '/etc'
+            config = os.path.join(config, 'droidlysis')
+            if os.path.exists(config):
+                filename = os.path.join(config, 'general.conf')
+        logging.debug(f'Reading config from {filename}')
+
         if not os.path.exists(filename):
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), filename)
         self.config = configparser.ConfigParser()

--- a/droidlysis3.py
+++ b/droidlysis3.py
@@ -83,7 +83,7 @@ def get_arguments():
                         action='store_true')
     parser.add_argument('--config',
                         help='general configuration file for DroidLysis',
-                        action='store', default='./conf/general.conf')
+                        action='store')
 
     args = parser.parse_args()
     if args.verbose:


### PR DESCRIPTION
`/etc/droidlysis` and `~/.config/droidlysis` are widespread defaults for config files, this allows them to be used, but only if `./conf/general.conf` does not exist.  For example, if they installed droidlysis via Debian, Homebrew or some other packaging system.

When `./conf/general.conf` is present, the behavior should be the same as before.